### PR TITLE
OUTLOOKS: fix legend colors not showing by moving dynamic color to style attr

### DIFF
--- a/src/features/convective-outlooks/CategoricalLegendKey.jsx
+++ b/src/features/convective-outlooks/CategoricalLegendKey.jsx
@@ -1,9 +1,10 @@
 export const CategoricalLegendKey = ({ colorStr, labelStr }) => {
-	const badgeStyles = `bg-[${colorStr}] h-2 w-2 rounded-sm sm:h-4 sm:w-4 sm:rounded-sm`;
-
 	return (
 		<div className='flex items-center'>
-			<div className={badgeStyles} />
+			<div
+				style={{ backgroundColor: `${colorStr}` }}
+				className='h-2 w-2 rounded-sm sm:h-4 sm:w-4'
+			/>
 			<span className='ml-2'>{labelStr}</span>
 		</div>
 	);


### PR DESCRIPTION
<img width="335" alt="image" src="https://github.com/modevx/tornado-warned/assets/86921531/47a466f2-efd9-4459-89f5-e190a830c221">
